### PR TITLE
Url replacement fix, Parameter changes

### DIFF
--- a/PyPhisher.py
+++ b/PyPhisher.py
@@ -1,7 +1,8 @@
 import smtplib
+import getpass
 import sys, argparse
 import re
-import base64 
+import base64
 import os
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -11,10 +12,10 @@ def banner():
 	print "#          PyPhisher            #"
 	print "#       by: sneakerhax          #"
 	print "#################################"
-	
+
 def main(args):
 	pish(args)
-	
+
 def pish(args):
 	message_html = open_html_file(args.html)
 	html_output = replace_links(args.url_replace, message_html)
@@ -25,12 +26,12 @@ def open_html_file(file):
 	with open(file, 'r') as open_html:
 		email_html = open_html.read()
 	return email_html
-	
+
 def replace_links(url, message):
-	html_regex = re.compile(r"""(?i)\b((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>\[\]]+|\(([^\s()<>\[\]]+|(\([^\s()<>\[\]]+\)))*\))+(?:\(([^\s()<>\[\]]+|(\([^\s()<>\[\]]+\)))*\)|[^\s`!(){};:'".,<>?\[\]]))""")
-	html_output = html_regex.sub(url, message)
+	html_regex = re.compile(r'href=[\'"]?([^\'" >]+)')
+	html_output = html_regex.sub("href=\"{}".format(url), message)
 	return html_output
-			
+
 def mime_message(subject, sendto, sender, html):
 	msg = MIMEMultipart('alternative')
 	msg['To'] = sendto
@@ -39,13 +40,23 @@ def mime_message(subject, sendto, sender, html):
 	message = MIMEText(html, 'html')
 	msg.attach(message)
 	return msg.as_string()
-	
+
 def send_email(server, port, username, password, sender, sendto, message):
+	print "[+] Attempting to connect to server"
 	s = smtplib.SMTP(server, port)
-	s.starttls()
-	s.ehlo()
-	s.login(username, password)
+	if args.starttls:
+		print "[+] Attempting to user STARTTLS"
+		s.starttls()
+	print "[+] Attempting to say ehlo"
+	s.helo()
+	if args.username is not None:
+		print "[+] Attempting to Authenticate"
+		if args.password is None:
+			password = getpass.getpass("Password for {}:".format(username))
+		s.login(username, password)
+	print "[+] Attempting to send mail"
 	s.sendmail(sender, sendto, message)
+	print "[+] Done..."
 	s.quit()
 
 if __name__ == '__main__':
@@ -60,10 +71,11 @@ if __name__ == '__main__':
 	parser.add_argument('--subject', action='store', dest='subject', type=str, help='subject of message')
 	parser.add_argument('--sender', action='store', dest='sender', type=str, help='email sender')
 	parser.add_argument('--sendto', action='store', dest='sendto', type=str, help='send to address')
+	parser.add_argument('--start-tls', action='store_true', dest='starttls', help='run using STARTTLS')	
 
 	args = parser.parse_args()
-	
+
 	banner()
 	main(args)
-		
-	
+
+

--- a/PyPhisher.py
+++ b/PyPhisher.py
@@ -45,7 +45,7 @@ def send_email(server, port, username, password, sender, sendto, message):
 	print "[+] Attempting to connect to server"
 	s = smtplib.SMTP(server, port)
 	if args.starttls:
-		print "[+] Attempting to user STARTTLS"
+		print "[+] Attempting to use STARTTLS"
 		s.starttls()
 	print "[+] Attempting to say ehlo"
 	s.helo()

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ PyPhisher.py --server mail.server.com --port 25 --username user --password passw
 --subject         The subject that will appear in the email message
 --sender          The sender that will appear on the email example
 --sendto          Who you would like to send the email to
---start-tls		Will attempt to upgrade connection using SSL/TLS
+--start-tls       Will attempt to upgrade connection using SSL/TLS
 ```
 If you need to check your credentials for your SMTP server use:<br>
 https://github.com/sneakerhax/Python-Network-Tools/blob/master/smtp_authcheck.py

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ PyPhisher.py --server mail.server.com --port 25 --username user --password passw
 --subject         The subject that will appear in the email message
 --sender          The sender that will appear on the email example
 --sendto          Who you would like to send the email to
---start-tls	  Will attempt to upgrade connection using SSL/TLS
+--start-tls		Will attempt to upgrade connection using SSL/TLS
 ```
 If you need to check your credentials for your SMTP server use:<br>
 https://github.com/sneakerhax/Python-Network-Tools/blob/master/smtp_authcheck.py

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ PyPhisher.py --server mail.server.com --port 25 --username user --password passw
 --subject         The subject that will appear in the email message
 --sender          The sender that will appear on the email example
 --sendto          Who you would like to send the email to
+--start-tls	  Will attempt to upgrade connection using SSL/TLS
 ```
 If you need to check your credentials for your SMTP server use:<br>
 https://github.com/sneakerhax/Python-Network-Tools/blob/master/smtp_authcheck.py


### PR DESCRIPTION
Changes URL replacement so it does not replace images, only hyperlinks. Added a argument --start-tls so that using STARTTLS is not default. Now only attempts to authenticate if username is specified. If password is not specified when username is, the user will be prompted.

closes #1 
closes #2 
closes #3 